### PR TITLE
[KSL][Experiment] #29 Kiwi 품사 기반 불용어 제거 전처리 구현

### DIFF
--- a/src/token_cleaning.py
+++ b/src/token_cleaning.py
@@ -3,21 +3,52 @@ from kiwipiepy import Kiwi
 # Kiwi 분석기 설정
 kiwi = Kiwi(model_type="sbg")
 
-# 제거할 불필요한 품사 접두어
-UNWANTED_POS_PREFIX = {"J", "E", "S", "X"}
-# 제거할 1글자 불용어 리스트 (의미 없음)
+# 제거할 불필요한 품사 태그 (정확히 명시)
+UNWANTED_TAGS = {
+    # 조사
+    "JKS", "JKC", "JKG", "JKO", "JKB", "JKV", "JKQ", "JX", "JC",
+    # 어미
+    "EP", "EF", "EC", "ETN", "ETM",
+    # 기호 및 특수문자
+    "SF", "SP", "SS", "SSO", "SSC", "SE", "SO", "SW",
+    # 접사
+    "XPN", "XSN", "XSV", "XSA"
+}
+
+# 제거할 1글자 불용어 리스트
 STOPWORDS = {"다", "요", "좀", "어", "이요", "나요", "께서", "?"}
 
 def analyze_kiwi_raw(sentence: str):
-    #형태소 분석 결과를 (형태소, 품사) 튜플 리스트로 반환
+    """
+    형태소 분석 결과를 (형태소, 품사) 튜플 리스트로 반환
+    """
     result = kiwi.analyze(sentence, top_n=1)[0][0]
     return [(word, tag) for word, tag, _, _ in result]
 
 def analyze_kiwi_clean(sentence: str):
-    #불용어 제거, 의미 있는 품사만 필터링한 결과를 반환
     result = kiwi.analyze(sentence, top_n=1)[0][0]
-    filtered = [
-        word for word, tag, _, _ in result
-        if tag[0] not in UNWANTED_POS_PREFIX and word not in STOPWORDS and len(word) > 1
-    ]
+    filtered = []
+    for word, tag, _, _ in result:
+        if tag in {"NNG", "NNP", "VV", "VA", "VX", "XR"}:
+            filtered.append(word)
+        elif tag in UNWANTED_TAGS or word in STOPWORDS:
+            continue
+        elif len(word) > 1:
+            filtered.append(word)
     return filtered
+
+
+
+if __name__ == "__main__":
+    test_sent = "홍수가 나서 집이 물에 잠기고 있어요."
+    #test_sent = "고속도로에서 자동차가 갑자기 멈췄어요."
+
+    print("🟡 입력 문장:", test_sent)
+
+    raw = analyze_kiwi_raw(test_sent)
+    print("\n🔍 분석 결과 (원본):")
+    print(" | ".join([f"{w}/{t}" for w, t in raw]))
+
+    clean = analyze_kiwi_clean(test_sent)
+    print("\n✅ 분석 결과 (불용어 제거):")
+    print(" | ".join(clean))

--- a/src/token_cleaning.py
+++ b/src/token_cleaning.py
@@ -1,0 +1,23 @@
+from kiwipiepy import Kiwi
+
+# Kiwi 분석기 설정
+kiwi = Kiwi(model_type="sbg")
+
+# 제거할 불필요한 품사 접두어
+UNWANTED_POS_PREFIX = {"J", "E", "S", "X"}
+# 제거할 1글자 불용어 리스트 (의미 없음)
+STOPWORDS = {"다", "요", "좀", "어", "이요", "나요", "께서", "?"}
+
+def analyze_kiwi_raw(sentence: str):
+    #형태소 분석 결과를 (형태소, 품사) 튜플 리스트로 반환
+    result = kiwi.analyze(sentence, top_n=1)[0][0]
+    return [(word, tag) for word, tag, _, _ in result]
+
+def analyze_kiwi_clean(sentence: str):
+    #불용어 제거, 의미 있는 품사만 필터링한 결과를 반환
+    result = kiwi.analyze(sentence, top_n=1)[0][0]
+    filtered = [
+        word for word, tag, _, _ in result
+        if tag[0] not in UNWANTED_POS_PREFIX and word not in STOPWORDS and len(word) > 1
+    ]
+    return filtered


### PR DESCRIPTION
✅ Kiwi 분석기 결과에서 불용어 제거 기반 전처리 기능 구현

- 공식 품사 태그 기준으로 불필요한 조사(J*), 어미(E*), 기호(S*), 접사(X*) 정확히 제거
- 의미 있는 품사(NNG, NNP, VV, VA, etc)는 유지되도록 로직 개선
- 의미 없는 1글자 단어(`다`, `요`, `좀`, `어` 등)는 STOPWORDS 리스트 기반 제거
- 테스트용 `__main__` 블록 포함 (로컬 실행 확인용)
<img width="896" alt="스크린샷 2025-04-14 오후 11 13 12" src="https://github.com/user-attachments/assets/ed3db3c8-3890-4a56-95ec-a22efc186aac" />

📁 주요 파일:
- `src/token_cleaning.py`

closes #29