### PR TITLE
[KSL][Feature] #38 gloss 매핑용 병렬 데이터셋 구축 및 저장 기능 구현

### DIFF
--- a/scripts/build_gloss_dataset.py
+++ b/scripts/build_gloss_dataset.py
@@ -1,0 +1,43 @@
+import os
+import json
+import csv
+
+# 입력 JSON들이 들어있는 디렉토리
+INPUT_DIR = "data/01_NIKL_Sign Language Parallel Corpus_2023"
+OUTPUT_PATH = "data/ksl_gloss_dataset.csv"
+
+results = []
+
+for filename in os.listdir(INPUT_DIR):
+    if not filename.endswith(".json"):
+        continue
+
+    path = os.path.join(INPUT_DIR, filename)
+
+    with open(path, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError:
+            print(f"❌ JSON 파싱 실패: {filename}")
+            continue
+
+    # ① 한국어 문장
+    korean = data.get("krlgg_sntenc", {}).get("koreanText", "").strip()
+
+    # ② 수어 gloss 리스트 추출
+    gestures = data.get("sign_script", {}).get("sign_gestures_strong", [])
+    glosses = [g.get("gloss_id") for g in gestures if g.get("gloss_id")]
+
+    if korean and glosses:
+        results.append({
+            "korean": korean,
+            "glosses": ", ".join(glosses)
+        })
+
+# 저장
+with open(OUTPUT_PATH, "w", newline="", encoding="utf-8") as f:
+    writer = csv.DictWriter(f, fieldnames=["korean", "glosses"])
+    writer.writeheader()
+    writer.writerows(results)
+
+print(f"✅ 추출 완료: {len(results)}개 샘플 저장됨 → {OUTPUT_PATH}")


### PR DESCRIPTION
- 국립국어원 병렬 JSON 파일에서 다음 항목 추출
  - `krlgg_sntenc.koreanText`: 한국어 문장
  - `sign_script.sign_gestures_strong[*].gloss_id`: 수어 gloss 목록

- 필터링 기준
  - gloss_id가 비어 있거나 문장이 없는 경우 제외

- 추출 완료: 105887개 샘플 저장됨
- 결과 저장: `data/ksl_gloss_dataset.csv`

close #38 